### PR TITLE
fix: allow no vue config

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,11 @@ const generateCompilerModule = require('./lib/')
 module.exports = (api, projectOptions) => {
   const defaultOptions = genDefOpts()
 
-  const pluginOptions = projectOptions.pluginOptions.testAttrs || {}
+  const pluginOptions =
+    (projectOptions &&
+      projectOptions.pluginOptions &&
+      projectOptions.pluginOptions.testAttrs) ||
+    {}
   const options = { ...defaultOptions, ...pluginOptions }
 
   if (options.enabled === false) return


### PR DESCRIPTION
If there is no `vue.config.js` file or no `pluginOptions` there, it breaks with a cannot read property 'testAttrs' of undefined